### PR TITLE
Add type hints to calculation utilities

### DIFF
--- a/utils/calculations.py
+++ b/utils/calculations.py
@@ -3,6 +3,8 @@
 QTOCalculator - Calculation utilities for Quantity Takeoff
 """
 
+from typing import Any, Dict, Union
+
 import FreeCAD
 
 class QTOCalculator:
@@ -11,7 +13,7 @@ class QTOCalculator:
     """
     
     @staticmethod
-    def get_object_properties(obj):
+    def get_object_properties(obj: Any) -> Dict[str, Union[str, float, int]]:
         """Extract properties from FreeCAD object"""
         try:
             properties = {
@@ -68,7 +70,7 @@ class QTOCalculator:
             }
     
     @staticmethod
-    def calculate_material_total(quantity, material_per_unit):
+    def calculate_material_total(quantity: float, material_per_unit: float) -> float:
         """Calculate material total cost"""
         try:
             return float(quantity) * float(material_per_unit)
@@ -76,7 +78,7 @@ class QTOCalculator:
             return 0.0
     
     @staticmethod
-    def calculate_labor_total(quantity, labor_per_unit):
+    def calculate_labor_total(quantity: float, labor_per_unit: float) -> float:
         """Calculate labor total cost"""
         try:
             return float(quantity) * float(labor_per_unit)
@@ -84,7 +86,7 @@ class QTOCalculator:
             return 0.0
     
     @staticmethod
-    def calculate_row_total(material_total, labor_total):
+    def calculate_row_total(material_total: float, labor_total: float) -> float:
         """Calculate total for a row"""
         try:
             return float(material_total) + float(labor_total)
@@ -92,7 +94,7 @@ class QTOCalculator:
             return 0.0
     
     @staticmethod
-    def format_currency(value):
+    def format_currency(value: float) -> str:
         """Format number as currency"""
         try:
             return f"{float(value):,.2f}"
@@ -100,7 +102,7 @@ class QTOCalculator:
             return "0.00"
     
     @staticmethod
-    def format_quantity(value):
+    def format_quantity(value: float) -> str:
         """Format quantity value"""
         try:
             return f"{float(value):,.0f}"
@@ -108,7 +110,7 @@ class QTOCalculator:
             return "0"
     
     @staticmethod
-    def format_dimension(value):
+    def format_dimension(value: float) -> str:
         """Format dimension value (meters)"""
         try:
             return f"{float(value):,.2f}"


### PR DESCRIPTION
## Summary
- add typing imports and annotations in calculation helpers
- annotate formatting and total computation utilities

## Testing
- `mypy utils/calculations.py --ignore-missing-imports`

------
https://chatgpt.com/codex/tasks/task_e_6896313ad8cc832e85a6632b468cafd6