### PR TITLE
Prefer Shape area with bounding box fallback

### DIFF
--- a/tests/test_area_calculation.py
+++ b/tests/test_area_calculation.py
@@ -1,0 +1,53 @@
+import unittest
+import types
+import sys
+
+try:
+    import FreeCAD, Part  # type: ignore
+    HAS_FREECAD = True
+except Exception:  # ModuleNotFoundError or others
+    HAS_FREECAD = False
+    FreeCAD = types.SimpleNamespace(  # type: ignore
+        Console=types.SimpleNamespace(PrintError=lambda msg: None)
+    )
+    sys.modules.setdefault("FreeCAD", FreeCAD)  # type: ignore
+    Part = None  # type: ignore
+
+from utils.calculations import QTOCalculator
+
+
+class TestAreaCalculation(unittest.TestCase):
+    @unittest.skipUnless(HAS_FREECAD, "FreeCAD not available")
+    def test_shape_area_preferred(self):
+        box = Part.makeBox(2000, 1000, 1000)  # dimensions in mm
+        obj = type("Obj", (), {})()
+        obj.Name = "Box"
+        obj.Label = "Box"
+        obj.TypeId = "Part::Box"
+        obj.Shape = box
+        properties = QTOCalculator.get_object_properties(obj)
+        self.assertAlmostEqual(properties["Area"], round(box.Area / 1_000_000, 2))
+
+    def test_bounding_box_fallback(self):
+        class DummyBoundBox:
+            XLength = 2000
+            YLength = 1000
+            ZLength = 1000
+
+        class DummyShape:
+            BoundBox = DummyBoundBox()
+            Area = 0
+            Volume = 2000 * 1000 * 1000
+
+        obj = type("Obj", (), {})()
+        obj.Name = "Dummy"
+        obj.Label = "Dummy"
+        obj.TypeId = "DummyType"
+        obj.Shape = DummyShape()
+        properties = QTOCalculator.get_object_properties(obj)
+        expected_area = round(properties["Length"] * properties["Width"], 2)
+        self.assertEqual(properties["Area"], expected_area)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/calculations.py
+++ b/utils/calculations.py
@@ -33,12 +33,17 @@ class QTOCalculator:
                 bbox = obj.Shape.BoundBox
                 # Convert from mm to m
                 properties['Length'] = round(bbox.XLength / 1000, 2)
-                properties['Width'] = round(bbox.YLength / 1000, 2) 
+                properties['Width'] = round(bbox.YLength / 1000, 2)
                 properties['Height'] = round(bbox.ZLength / 1000, 2)
                 properties['Volume'] = round(obj.Shape.Volume / 1000000000, 6)  # mm³ to m³
-                
-                # Calculate area (using bounding box approximation)
-                if properties['Height'] > 0:
+
+                # Prefer actual shape area when available
+                if hasattr(obj.Shape, 'Area') and obj.Shape.Area:
+                    properties['Area'] = round(obj.Shape.Area / 1000000, 2)  # mm² to m²
+                elif hasattr(obj, 'Area') and obj.Area:
+                    properties['Area'] = round(obj.Area / 1000000, 2)  # mm² to m²
+                elif properties['Height'] > 0:
+                    # Fallback to bounding box approximation
                     properties['Area'] = round((properties['Length'] * properties['Width']), 2)
             
             # Try to get specific properties for different object types


### PR DESCRIPTION
## Summary
- use `Shape.Area` or object `Area` if available for more accurate area calculations
- fall back to bounding box width × length when precise area is missing
- add unit tests covering shape area and bounding box fallback

## Testing
- `python -m unittest tests/test_area_calculation.py -v`


------
https://chatgpt.com/codex/tasks/task_e_689631397f80832e9a0e994a545a4a4b